### PR TITLE
Add simple website

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ You can customize VCopy’s behavior using the following settings:
 
 - VS Code 1.70.0 or higher
 
+## Website
+A simple informational website is included in the `website/` folder. Open `website/index.html` in your browser to view it locally.
+
 ## Contributing
 
 Found a bug or have a feature request? Please open an issue on the repository.

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>gentleBits</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <img src="../img/icon.png" alt="gentleBits logo" class="logo">
+    <h1>gentleBits</h1>
+  </header>
+  <main>
+    <section>
+      <h2>Our Mission</h2>
+      <p>gentleBits aims to automate complex processes with large language models so you can focus on solving real problems. We build tools that make AI integration seamless for everyday tasks.</p>
+    </section>
+    <section>
+      <h2>Contact</h2>
+      <p>Have questions or want to collaborate? Reach out at <a href="mailto:info@gentlebits.com">info@gentlebits.com</a>.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 gentleBits</p>
+  </footer>
+</body>
+</html>

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  background: #f9f9f9;
+}
+header {
+  background: #333;
+  color: white;
+  padding: 1em;
+  display: flex;
+  align-items: center;
+}
+.logo {
+  width: 40px;
+  height: 40px;
+  margin-right: 1em;
+}
+main {
+  padding: 1em;
+}
+footer {
+  text-align: center;
+  padding: 1em;
+  background: #333;
+  color: white;
+}


### PR DESCRIPTION
## Summary
- add `website/` folder with `index.html` and `style.css`
- reference existing icon
- document website usage in README

## Testing
- `npm test` *(fails: Cannot find module '/workspace/vcopy/out/test/runTest.js')*